### PR TITLE
feat: add cli operations for app.py --status, --version & testing in pytest

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,4 +1,5 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 """
 URL-SHORTENER V0
@@ -6,6 +7,10 @@ URL-SHORTENER V0
 
 import argparse
 >>>>>>> b29e564 (feat: add base function cli and logic for __main__)
+=======
+import argparse
+import sys
+>>>>>>> ce62f8e (feat: cli argument parser implemented)
 import json
 import uvicorn
 from fastapi import FastAPI, Request, Form
@@ -14,17 +19,10 @@ from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
+VERSION = "-0"
+
 app = FastAPI()
 
-
-def cli() -> bool:
-    """
-    Parsea CLI flags 
-    :return: True si se pasan argumentos de línea de comandos,
-             False si no se pasan argumentos.
-    """
-    parser = argparse.ArgumentParser()
-    
 
 def read_config():
     with open("../config.json") as f:
@@ -99,6 +97,28 @@ async def home(request: Request):
     })
 
 
+def cli() -> bool:
+    """
+    Parsea CLI flags antes de ejecutar el servidor.
+    :return: True si se pasan argumentos de línea de comandos,
+             False si no se pasan argumentos.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--status", action="store_true", help="Verifica si el servidor está corriendo")
+    parser.add_argument("--version", action="store_true", help="Muestra la versión del servidor")
+
+    args, _ = parser.parse_known_args()
+
+    if args.status:
+        print("OK")
+        return True
+
+    if args.version:
+        print(VERSION)
+        return True
+    return False
+
+
 if __name__ == "__main__":
 <<<<<<< HEAD
     print('Versión 0')
@@ -112,6 +132,5 @@ if __name__ == "__main__":
     if cli():
         sys.exit(0)
 
-    print('V0')
     uvicorn.run("app:app", host=HOST, port=PORT, reload=True)
 >>>>>>> b29e564 (feat: add base function cli and logic for __main__)

--- a/app/app.py
+++ b/app/app.py
@@ -1,3 +1,11 @@
+<<<<<<< HEAD
+=======
+"""
+URL-SHORTENER V0
+"""
+
+import argparse
+>>>>>>> b29e564 (feat: add base function cli and logic for __main__)
 import json
 import uvicorn
 from fastapi import FastAPI, Request, Form
@@ -8,6 +16,15 @@ from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
 
+
+def cli() -> bool:
+    """
+    Parsea CLI flags 
+    :return: True si se pasan argumentos de línea de comandos,
+             False si no se pasan argumentos.
+    """
+    parser = argparse.ArgumentParser()
+    
 
 def read_config():
     with open("../config.json") as f:
@@ -83,6 +100,18 @@ async def home(request: Request):
 
 
 if __name__ == "__main__":
+<<<<<<< HEAD
     print('Versión 0')
 
     uvicorn.run("app:app", host=HOST, port=PORT, reload=True)
+=======
+    """
+    Ejecuta el servidor uvicorn, si es que no se pasan
+    argumentos de línea de comandos.
+    """
+    if cli():
+        sys.exit(0)
+
+    print('V0')
+    uvicorn.run("app:app", host=HOST, port=PORT, reload=True)
+>>>>>>> b29e564 (feat: add base function cli and logic for __main__)

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -1,0 +1,33 @@
+import subprocess
+from pathlib import Path
+import sys
+
+APP_ROUTE = Path(__file__).parent.parent / "app" / "app.py"
+
+
+def run_cli(flag):
+    """
+    Test básico para verificar el funcionamiento de las operaciones CLI de root/app/app.py.
+    Comprueba que los comandos --status y --version funcionen correctamente.
+    """
+    result = subprocess.run(
+        [sys.executable, str(APP_ROUTE), flag],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+    return result.stdout.strip()
+
+
+def test_status():
+    """
+    Verifica que el comando --status retorne 'OK'.
+    """
+    assert run_cli("--status") == 'OK'
+
+
+def test_version():
+    """
+    Verifica que el comando --version retorne la versión del servidor.
+    """
+    assert run_cli("--version") == "-0"


### PR DESCRIPTION
*** CLI operations execution
```bash
amirmiir@zenbook14-aacg-EndOS:~/Escritorio/.UNI/PC3-Proyecto-11/app(feature/cli_ops)$ python app.py --status
OK
amirmiir@zenbook14-aacg-EndOS:~/Escritorio/.UNI/PC3-Proyecto-11/app(feature/cli_ops)$ python app.py --version
-0
```

*** Testing:
```
pytest -v test_cli_ops.py 
================================================================================ test session starts =================================================================================
platform linux -- Python 3.13.3, pytest-8.4.0, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/amirmiir/Escritorio/.UNI/PC3-Proyecto-11/tests
plugins: mock-3.14.0, anyio-4.9.0
collected 2 items                                                                                                                                                                    

test_cli_ops.py::test_status PASSED                                                                                                                                            [ 50%]
test_cli_ops.py::test_version PASSED                                                                                                                                           [100%]

================================================================================= 2 passed in 1.40s ==================================================================================
```